### PR TITLE
feat: expose application metrics with Micrometer and Prometheus integration (#12)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,12 @@
 			<artifactId>logstash-logback-encoder</artifactId>
 			<version>7.4</version>
 		</dependency>
+
+		<!--Metrics dependencies-->
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/enicar/taskManagementApi/Controller/TaskController.java
+++ b/src/main/java/com/enicar/taskManagementApi/Controller/TaskController.java
@@ -4,11 +4,16 @@ package com.enicar.taskManagementApi.Controller;
 import com.enicar.taskManagementApi.dto.TaskRequest;
 import com.enicar.taskManagementApi.dto.TaskResponse;
 import com.enicar.taskManagementApi.Service.TaskService;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 import java.util.List;
 
@@ -18,38 +23,65 @@ import java.util.List;
 public class TaskController {
 
     private final TaskService taskService;
+    
+    // Metrics
+    private final Counter taskCreateCounter;
+    private final Counter taskRetrievalCounter;
+    private final Counter taskDeletionCounter;
+    private final Timer taskRetrievalTimer;
 
-    public TaskController(TaskService taskService) {
+    public TaskController(TaskService taskService, MeterRegistry meterRegistry) {
         this.taskService = taskService;
+        
+        this.taskCreateCounter = Counter.builder("tasks.create.request")
+                .description("Total number of task creation requests")
+                .register(meterRegistry);
+        this.taskRetrievalCounter = Counter.builder("tasks.retrieval.total")
+                .description("Total number of task retrieval requests")
+                .register(meterRegistry);
+        this.taskDeletionCounter = Counter.builder("tasks.deletion.request")
+                .description("Total number of task deletion requests")
+                .register(meterRegistry);
+        this.taskRetrievalTimer = Timer.builder("tasks.retrieval.timer")
+                .description("Time taken to retrieve tasks")
+                .register(meterRegistry);
     }
 
     @GetMapping
     public ResponseEntity<List<TaskResponse>> getAllTasks() {
         log.info("GET /tasks - Fetching all tasks");
-        List<TaskResponse> tasks = taskService.getAllTasks();
-        log.info("GET /tasks - Successfully retrieved {} tasks", tasks.size());
-        return ResponseEntity.ok(tasks);
+        return taskRetrievalTimer.record(() -> {
+            taskRetrievalCounter.increment();
+            List<TaskResponse> tasks = taskService.getAllTasks();
+            log.info("GET /tasks - Successfully retrieved {} tasks", tasks.size());
+            return ResponseEntity.ok(tasks);
+        });
     }
 
     @PostMapping
     public ResponseEntity<TaskResponse> createTask(@Valid @RequestBody TaskRequest request) {
         log.info("POST /tasks - Creating new task with title: '{}'", request.title());
+        taskCreateCounter.increment();
         TaskResponse response = taskService.createTask(request);
         log.info("POST /tasks - Successfully created task with ID: {}", response.id());
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        URI location = URI.create(String.format("/tasks/%s", response.id()));
+        return ResponseEntity.created(location).body(response);
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<TaskResponse> getTaskById(@PathVariable Long id) {
         log.info("GET /tasks/{} - Fetching task by ID", id);
-        try {
-            TaskResponse response = taskService.getTaskById(id);
-            log.info("GET /tasks/{} - Successfully retrieved task", id);
-            return ResponseEntity.ok(response);
-        } catch (RuntimeException e) {
-            log.error("GET /tasks/{} - Task not found: {}", id, e.getMessage());
-            return ResponseEntity.notFound().build();
-        }
+        return taskRetrievalTimer.record(() -> {
+            taskRetrievalCounter.increment();
+            try {
+                TaskResponse response = taskService.getTaskById(id);
+                log.info("GET /tasks/{} - Successfully retrieved task", id);
+                return ResponseEntity.ok(response);
+            } catch (RuntimeException e) {
+                log.error("GET /tasks/{} - Task not found: {}", id, e.getMessage());
+                return ResponseEntity.notFound().build();
+            }
+        });
     }
 
     @PutMapping("/{id}")
@@ -70,6 +102,7 @@ public class TaskController {
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
         log.info("DELETE /tasks/{} - Deleting task", id);
+        taskDeletionCounter.increment();
         try {
             taskService.deleteTask(id);
             log.info("DELETE /tasks/{} - Successfully deleted task", id);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,12 @@ logging.level.com.enicar.taskManagementApi=INFO
 logging.level.org.springframework.web=INFO
 logging.level.org.hibernate=INFO
 
+# Actuator configuration
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoint.health.show-details=always
+management.prometheus.metrics.export.enabled=true
+
+
 
 
 


### PR DESCRIPTION
Added metrics for measuring :

- Number of task creation requests
- Number of task retrieval requests
- Number of task deletion requests
- Task retrieval execution time

The collected metrics are exposed through **Spring Boot Actuator** at `http://localhost:<<PORT>>/actuator `
They are also available in **Prometheus** format at `http://localhost:<<PORT>>/actuator/prometheus`