### PR TITLE
feat: add tracing configuration and dependencies for enhanced observability (#14)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,16 @@
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-prometheus</artifactId>
 		</dependency>
+
+		<!--Tracing dependencies-->
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,10 @@ logging.level.com.enicar.taskManagementApi=INFO
 logging.level.org.springframework.web=INFO
 logging.level.org.hibernate=INFO
 
+# Tracing configuration
+management.tracing.sampling.probability=1.0
+management.tracing.enabled=true
+
 # Actuator configuration
 management.endpoints.web.exposure.include=health,info,metrics,prometheus
 management.endpoint.health.show-details=always

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,9 +4,12 @@
     <!-- Console Appender -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%cyan(timestamp=%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX})
+            <pattern>
+                %cyan(timestamp=%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX})
                 %highlight(level=%level)
                 %magenta(thread=%thread)
+                %boldRed(traceId=%X{traceId:-N/A})
+                %boldRed(spanId=%X{spanId:-N/A})
                 %yellow(logger=%logger)
                 %green(message="%msg")
                 %n
@@ -21,7 +24,9 @@
             <pattern>timestamp=%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}
                 level=%-5level
                 thread=%thread
-                logger=%logger{36}
+                traceId=%X{traceId:-N/A}
+                spanId=%X{spanId:-N/A}
+                logger=%logger
                 message="%msg"
                 %n
             </pattern>
@@ -54,7 +59,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>timestamp=%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %n level=%-5level %n thread=%thread %n logger=%logger{36} %n message="%msg" %n</pattern>
+            <pattern>timestamp=%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %n level=%-5level %n thread=%thread %n traceId=%X{traceId:-N/A} %n spanId=%X{spanId:-N/A} %n logger=%logger %n message="%msg" %n</pattern>
             <charset>UTF-8</charset>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">


### PR DESCRIPTION
Added distributed tracing support using Micrometer Tracing with Brave implementation. All incoming HTTP requests now include `traceId `and `spanId` in log entries for better request tracking and debugging.

Dependencies Added:

- Micrometer tracing bridge for Brave

```
<dependency>
	<groupId>io.micrometer</groupId>
	<artifactId>micrometer-tracing-bridge-brave</artifactId>
</dependency>
```

- Brave tracing implementation and reporter

```
<dependency>
	<groupId>io.zipkin.reporter2</groupId>
	<artifactId>zipkin-reporter-brave</artifactId>
</dependency>
```
> [!NOTE]
>Trace and Span IDs display as N/A for non-HTTP request logs (startup, background tasks)
