### PR TITLE
feat: add GitHub Actions workflow to build and push Docker image to Docker Hub (#26)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,47 @@
+name: Build and Push Docker Image to Docker Hub
+
+permissions:
+  contents: read
+  pull-requests: read
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/task-management-api
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix={{branch}}-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/task-management-api:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/task-management-api:buildcache,mode=max


### PR DESCRIPTION
Added automated Docker image building and publishing to Docker Hub using GitHub Actions.

- [x] GitHub Actions workflow `docker-publish.yml`
- [x] Main branch only triggers - No PR clutter on Docker Hub
- [x] Docker Hub authentication via GitHub secrets
- [x] Docker layer caching for faster builds
- [x] Dual tagging: latest + commit-based tags (main-<sha>)